### PR TITLE
chore: on dependabot PR disable coverage steps

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,6 +40,7 @@ jobs:
     
     - name: Copy coverage report to predictable location
       run: cp coverage/**/coverage.cobertura.xml coverage/coverage.cobertura.xml
+      if: github.actor!= 'dependabot-preview[bot]'
       
     - name: Generate code coverage summary report
       uses: irongut/CodeCoverageSummary@v1.2.0
@@ -48,10 +49,11 @@ jobs:
         badge: true
         format: 'markdown'
         output: 'both'
+      if: github.actor!= 'dependabot-preview[bot]'
 
     - name: Add coverage report into PR comment
       uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && github.actor!= 'dependabot-preview[bot]'
       with:
         recreate: true
         path: code-coverage-results.md


### PR DESCRIPTION
Fix "Error: Resource not accessible by integration" occurring when sticky-pull-request-comment is executed.